### PR TITLE
X11 requirement when using reference panels

### DIFF
--- a/STITCH.R
+++ b/STITCH.R
@@ -408,6 +408,12 @@ option_list <- list(
         default = TRUE
     ), 
     make_option(
+        "--plotReferenceAlleleCount",
+        type = "logical",
+        help = "Generate plot of reference allele counts, set to FALSE for systmems without x11 [default TRUE]",
+        default = TRUE
+    ),
+    make_option(
         "--save_sampleReadsInfo",
         type = "logical",
         help = "Experimental. Boolean TRUE/FALSE about whether to save additional information about the reads that were extracted [default FALSE] ",
@@ -534,6 +540,7 @@ STITCH(
     plotHapSumDuringIterations = opt$plotHapSumDuringIterations,
     plot_shuffle_haplotype_attempts = opt$plot_shuffle_haplotype_attempts,
     plotAfterImputation = opt$plotAfterImputation,
+    plotReferenceAlleleCount = opt$plotReferenceAlleleCount,
     save_sampleReadsInfo = opt$save_sampleReadsInfo,
     gridWindowSize = opt$gridWindowSize,
     shuffle_bin_nSNPs = opt$shuffle_bin_nSNPs,

--- a/STITCH/R/functions.R
+++ b/STITCH/R/functions.R
@@ -150,6 +150,7 @@ STITCH <- function(
     plotHapSumDuringIterations = FALSE,
     plot_shuffle_haplotype_attempts = FALSE,
     plotAfterImputation = TRUE,
+    plotReferenceAlleleCount = TRUE,
     save_sampleReadsInfo = FALSE,
     gridWindowSize = NA,
     shuffle_bin_nSNPs = NULL,
@@ -537,7 +538,8 @@ STITCH <- function(
     ##
     ## initialize variables
     ##
-    out <- initialize_parameters(reference_haplotype_file = reference_haplotype_file, reference_legend_file = reference_legend_file, reference_sample_file = reference_sample_file, reference_populations = reference_populations, reference_phred = reference_phred, reference_iterations = reference_iterations, nSNPs = nSNPs, K = K, S = S, L = L, pos = pos, inputBundleBlockSize = inputBundleBlockSize, nCores = nCores, regionName = regionName, alleleCount = alleleCount, expRate = expRate, nGen = nGen, tempdir = tempdir, outputdir = outputdir, pseudoHaploidModel = pseudoHaploidModel, emissionThreshold = emissionThreshold, alphaMatThreshold = alphaMatThreshold, minRate = minRate, maxRate = maxRate, regionStart = regionStart, regionEnd = regionEnd, buffer = buffer, niterations = niterations, grid = grid, grid_distances = grid_distances, nGrids = nGrids, reference_shuffleHaplotypeIterations = reference_shuffleHaplotypeIterations, L_grid = L_grid, plot_shuffle_haplotype_attempts = plot_shuffle_haplotype_attempts, shuffle_bin_radius = shuffle_bin_radius, snps_in_grid_1_based = snps_in_grid_1_based, plotHapSumDuringIterations = plotHapSumDuringIterations, cM_grid = cM_grid)
+    out <- initialize_parameters(reference_haplotype_file = reference_haplotype_file, reference_legend_file = reference_legend_file, reference_sample_file = reference_sample_file, reference_populations = reference_populations, reference_phred = reference_phred, reference_iterations = reference_iterations, nSNPs = nSNPs, K = K, S = S, L = L, pos = pos, inputBundleBlockSize = inputBundleBlockSize, nCores = nCores, regionName = regionName, alleleCount = alleleCount, expRate = expRate, nGen = nGen, tempdir = tempdir, outputdir = outputdir, pseudoHaploidModel = pseudoHaploidModel, emissionThreshold = emissionThreshold, alphaMatThreshold = alphaMatThreshold, minRate = minRate, maxRate = maxRate, regionStart = regionStart, regionEnd = regionEnd, buffer = buffer, niterations = niterations, grid = grid, grid_distances = grid_distances, nGrids = nGrids, reference_shuffleHaplotypeIterations = reference_shuffleHaplotypeIterations, L_grid = L_grid, plot_shuffle_haplotype_attempts = plot_shuffle_haplotype_attempts, shuffle_bin_radius = shuffle_bin_radius, snps_in_grid_1_based = snps_in_grid_1_based, plotHapSumDuringIterations = plotHapSumDuringIterations, cM_grid = cM_grid,
+    plotReferenceAlleleCount = plotReferenceAlleleCount)
     eHapsCurrent_tc <- out$eHapsCurrent_tc
     alphaMatCurrent_tc <- out$alphaMatCurrent_tc
     hapSumCurrent_tc <- out$hapSumCurrent_tc
@@ -1318,7 +1320,8 @@ initialize_parameters <- function(
     shuffle_bin_radius,
     snps_in_grid_1_based,
     plotHapSumDuringIterations,
-    cM_grid
+    cM_grid,
+    plotReferenceAlleleCount
 ) {
 
     print_message("Begin parameter initialization")
@@ -1370,7 +1373,40 @@ initialize_parameters <- function(
             hapSumCurrent_tc = hapSumCurrent_tc,
             sigmaCurrent_m = sigmaCurrent_m,
             priorCurrent_m = priorCurrent_m,
-            reference_haplotype_file = reference_haplotype_file, reference_legend_file = reference_legend_file, reference_sample_file = reference_sample_file, reference_populations = reference_populations, reference_phred = reference_phred, reference_iterations = reference_iterations, nSNPs = nSNPs, K = K, S = S, L = L, pos = pos, inputBundleBlockSize = inputBundleBlockSize, nCores = nCores, regionName = regionName, alleleCount = alleleCount, expRate = expRate, nGen = nGen, tempdir = tempdir, outputdir = outputdir, pseudoHaploidModel = pseudoHaploidModel, emissionThreshold = emissionThreshold, alphaMatThreshold = alphaMatThreshold, minRate = minRate, maxRate = maxRate, regionStart = regionStart, regionEnd = regionEnd, buffer = buffer, niterations = niterations, grid = grid, grid_distances = grid_distances, nGrids = nGrids, reference_shuffleHaplotypeIterations = reference_shuffleHaplotypeIterations, L_grid = L_grid, plot_shuffle_haplotype_attempts = plot_shuffle_haplotype_attempts, shuffle_bin_radius = shuffle_bin_radius, snps_in_grid_1_based = snps_in_grid_1_based, plotHapSumDuringIterations = plotHapSumDuringIterations)
+            reference_haplotype_file = reference_haplotype_file,
+            reference_legend_file = reference_legend_file,
+            reference_sample_file = reference_sample_file,
+            reference_populations = reference_populations,
+            reference_phred = reference_phred,
+            reference_iterations = reference_iterations,
+            nSNPs = nSNPs,
+            K = K, S = S, L = L,
+            pos = pos,
+            inputBundleBlockSize = inputBundleBlockSize,
+            nCores = nCores,
+            regionName = regionName,
+            alleleCount = alleleCount,
+            expRate = expRate,
+            nGen = nGen,
+            tempdir = tempdir,
+            outputdir = outputdir,
+            pseudoHaploidModel = pseudoHaploidModel,
+            emissionThreshold = emissionThreshold,
+            alphaMatThreshold = alphaMatThreshold,
+            minRate = minRate,
+            maxRate = maxRate,
+            regionStart = regionStart,
+            regionEnd = regionEnd,
+            buffer = buffer,
+            niterations = niterations,
+            grid = grid, grid_distances = grid_distances, nGrids = nGrids,
+            reference_shuffleHaplotypeIterations = reference_shuffleHaplotypeIterations,
+            L_grid = L_grid,
+            plot_shuffle_haplotype_attempts = plot_shuffle_haplotype_attempts,
+            shuffle_bin_radius = shuffle_bin_radius,
+            snps_in_grid_1_based = snps_in_grid_1_based,
+            plotHapSumDuringIterations = plotHapSumDuringIterations,
+            plotReferenceAlleleCount = plotReferenceAlleleCount)
     }
 
     print_message("Done parameter initialization")	

--- a/STITCH/R/reference.R
+++ b/STITCH/R/reference.R
@@ -40,7 +40,8 @@ get_and_initialize_from_reference <- function(
     plot_shuffle_haplotype_attempts,
     shuffle_bin_radius,
     snps_in_grid_1_based,
-    plotHapSumDuringIterations
+    plotHapSumDuringIterations,
+    plotReferenceAlleleCount
 ) {
 
     ## quick validations of haps against sample file
@@ -93,7 +94,8 @@ get_and_initialize_from_reference <- function(
             alleleCount = alleleCount,
             ref_alleleCount = ref_alleleCount,
             outputdir = outputdir,
-            regionName = regionName
+            regionName = regionName,
+            plot_ref_allele_count = plotReferenceAlleleCount
         )
     }
 
@@ -424,7 +426,8 @@ compare_reference_haps_against_alleleCount <- function(
     alleleCount,
     ref_alleleCount,
     outputdir,
-    regionName
+    regionName,
+    plot_ref_allele_count
 ) {
 
     all_cor <- suppressWarnings(
@@ -452,11 +455,13 @@ compare_reference_haps_against_alleleCount <- function(
     print_message(paste0(round(high_maf_cor, 3), " for > 5% MAF SNPs"))
     print_message(paste0(round(low_maf_cor, 3), " for < 5% MAF SNPs"))
 
-    out_plot <- file.path(outputdir, "plots", paste0("alleleFrequency_pileup_vs_reference_haplotypes.", regionName, ".png"))
-    print_message(paste0("A plot of allele frequencies from sequencing pileup vs reference haplotype counts is at:", out_plot))
-    png(out_plot, height = 500, width = 500)
-    plot(alleleCount[, 3], ref_alleleCount[, 3], xlab = "Allele frequency from pileup", ylab = "Allele frequency from reference haplotypes")
-    dev.off()
+    if (plot_ref_allele_count) {
+        out_plot <- file.path(outputdir, "plots", paste0("alleleFrequency_pileup_vs_reference_haplotypes.", regionName, ".png"))
+        print_message(paste0("A plot of allele frequencies from sequencing pileup vs reference haplotype counts is at:", out_plot))
+        png(out_plot, height = 500, width = 500)
+        plot(alleleCount[, 3], ref_alleleCount[, 3], xlab = "Allele frequency from pileup", ylab = "Allele frequency from reference haplotypes")
+        dev.off()
+    }
 
     return(NULL)
 


### PR DESCRIPTION
This update adds a flag to STITCH that when running with a reference panel generating plot in `compare_reference_haps_against_alleleCount` is optional.  This address issue #104 